### PR TITLE
Regex Cleanup

### DIFF
--- a/yara/slowpulse2.yar
+++ b/yara/slowpulse2.yar
@@ -9,7 +9,7 @@ rule FE_APT_Backdoor_Linux32_SLOWPULSE_2
         $sig = /[\x20-\x7F]{16}([\x20-\x7F\x00]+)\x00.{1,32}\xE9.{3}\xFF\x00+[\x20-\x7F][\x20-\x7F\x00]{16}/ 
 
         // TOI_MAGIC_STRING 
-        $exc1 = /\xED\xC3\x02\xE9\x98\x56\xE5\x0C/ 
+        $exc1 = {ED C3 02 E9 98 56 E5 0C}
     condition:
         uint32(0) == 0x464C457F and (1 of ($sig*)) and (not (1 of ($exc*)))
 }


### PR DESCRIPTION
Regex is not needed for a static hexadecimal string.

https://yara.readthedocs.io/en/stable/writingrules.html#hexadecimal-strings

This signature still slows down scanning, and will fail if you have `--fail-on-warnings` enabled.

I would need the full sample to make a PR to fix the whole signature.