### PR TITLE
Corrected meta syntax

### DIFF
--- a/yara/bloodbank.yar
+++ b/yara/bloodbank.yar
@@ -3,8 +3,8 @@ rule FE_APT_Tool_Linux32_BLOODBANK_1
     meta: 
         author = "Mandiant"  
         date_created = "2021-05-17" 
-        SHA256: 8bd504ac5fb342d3533fbe0febe7de5c2adcf74a13942c073de6a9db810f9936 
-        reference url= "" 
+        sha256 = "8bd504ac5fb342d3533fbe0febe7de5c2adcf74a13942c073de6a9db810f9936" 
+        reference_url = "https://www.fireeye.com/blog/threat-research/2021/05/updates-on-chinese-apt-compromising-pulse-secure-vpn-devices.html" 
     strings: 
         $sb1 = {0f b6 00 3c 75 [2-6] 8b 85 [4] 8d ?? 01 8b 85 [4] 01 ?? 0f b6 00 3c 73 [2-6] 8b 85 [4]  8d ?? 02 8b 85 [4] 01 ?? 0f b6 00 3c 65 [2-6] 8b 85 [4] 8d ?? 03 8b 85 [4] 01 ?? 0f b6 00 3c 72 [2-6] 8b 85 [4] 8d ?? 04 8b 85 [4] 01 ?? 0f b6 00 3c 40} 
         $sb2 = {0f b6 00 3c 70 [2-6] 8b 85 [4] 8d ?? 01 8b 85 [4] 01 ?? 0f b6 00 3c 61 [2-6] 8b 85 [4]  8d ?? 02 8b 85 [4] 01 ?? 0f b6 00 3c 73 [2-6] 8b 85 [4] 8d ?? 03 8b 85 [4] 01 ?? 0f b6 00 3c 73 [2-6] 8b 85 [4] 8d ?? 04 8b 85 [4] 01 ?? 0f b6 00 3c 77 [2-6] 8b 85 [4] 8d ?? 08 8b 85 [4] 01 ?? 0f b6 00 3c 40} 

--- a/yara/bloodbank2.yar
+++ b/yara/bloodbank2.yar
@@ -3,8 +3,8 @@ rule FE_APT_Tool_Linux_BLOODBANK_2
     meta: 
         author = "Mandiant"  
         date_created = "2021-05-17" 
-        SHA256: 8bd504ac5fb342d3533fbe0febe7de5c2adcf74a13942c073de6a9db810f9936 
-        reference url= "" 
+        sha256 = "8bd504ac5fb342d3533fbe0febe7de5c2adcf74a13942c073de6a9db810f9936" 
+        reference_url = "https://www.fireeye.com/blog/threat-research/2021/05/updates-on-chinese-apt-compromising-pulse-secure-vpn-devices.html"  
     strings: 
         $ss1 = "\x00:%4d-%02d-%02d %02d:%02d:%02d  \x00" 
         $ss2 = "\x00ok!\x00" 

--- a/yara/bloodmine.yar
+++ b/yara/bloodmine.yar
@@ -3,8 +3,8 @@ rule FE_APT_Tool_Linux32_BLOODMINE_1
     meta: 
         author = "Mandiant" 
         date_created = "2021-05-17" 
-        SHA256: 38705184975684c826be28302f5e998cdb3726139aad9f8a6889af34eb2b0385 
-        reference url= "" 
+        sha256 = "38705184975684c826be28302f5e998cdb3726139aad9f8a6889af34eb2b0385" 
+        reference_url = "https://www.fireeye.com/blog/threat-research/2021/05/updates-on-chinese-apt-compromising-pulse-secure-vpn-devices.html" 
     strings: 
         $sb1 = { 6A 01 6A 03 68 [4] E8 [4-32] 50 E8 [4-32] 6A 01 5? 50 E8 [4-32] 50 E8 [4-32] 6A 01 5? 50 E8 [4-32] 6A 01 6A 01 68 [4] E8 [4-32] 8? [0-2] 01 A1 [4] 39 [2] 0F 8? }
         $sb2 = { 68 [4] FF B5 [4] E8 [4-16] 85 C0 7? ?? C7 05 [4] 01 00 00 00 E9 [4-32] 68 [4] FF B5 [4] E8 [4-16] 85 C0 7? ?? C7 05 [4] 02 00 00 00 E9 [4-32] 68 [4] FF B5 [4] E8 [4-16] 85 C0 7? ?? C7 05 [4] 03 00 00 00 E9 } 

--- a/yara/bloodmine2.yar
+++ b/yara/bloodmine2.yar
@@ -3,8 +3,8 @@ rule FE_APT_Tool_Linux_BLOODMINE_2
     meta: 
         author = "Mandiant"  
         date_created = "2021-05-17" 
-        SHA256: 38705184975684c826be28302f5e998cdb3726139aad9f8a6889af34eb2b0385  
-        reference url= "" 
+        sha256 = "38705184975684c826be28302f5e998cdb3726139aad9f8a6889af34eb2b0385" 
+        reference_url = "https://www.fireeye.com/blog/threat-research/2021/05/updates-on-chinese-apt-compromising-pulse-secure-vpn-devices.html" 
     strings: 
         $ss1 = "\x00[+]\x00" 
         $ss2 = "\x00%d-%d-%d-%d-%d-%d\x0a\x00" 

--- a/yara/cleanpulse.yar
+++ b/yara/cleanpulse.yar
@@ -3,8 +3,8 @@ rule FE_APT_Tool_Linux32_CLEANPULSE_1
     meta: 
         author = "Mandiant"  
         date_created = "2021-05-17" 
-        SHA256: 9308cfbd697e4bf76fcc8ff71429fbdfe375441e8c8c10519b6a73a776801ba7 
-        reference url= "" 
+        sha256 = "9308cfbd697e4bf76fcc8ff71429fbdfe375441e8c8c10519b6a73a776801ba7" 
+        reference_url = "https://www.fireeye.com/blog/threat-research/2021/05/updates-on-chinese-apt-compromising-pulse-secure-vpn-devices.html" 
     strings: 
         $sb1 = { A1 [4] 8B [5] 50 68 [4] 5? FF 75 ?? E8 [4] 83 C4 10 A1 [4] 8B [5] 50 68 [4] 5? FF 75 ?? E8 [4] 83 C4 10 A1 [4] 8B [5] 50 68 [4] 5? FF 75 ?? E8 [4] 83 C4 10 A1 [4] 8B [5] 50 68 [4] 5? FF 75 ?? E8 [4] 83 C4 10 8B ?? 04 } 
         $sb2 = { 8B 00 0F B6 00 3C ?? 74 0F 8B ?? 04 83 C0 10 8B 00 0F B6 00 3C ?? 75 } 

--- a/yara/cleanpulse2.yar
+++ b/yara/cleanpulse2.yar
@@ -3,8 +3,8 @@ rule FE_APT_Tool_Linux_CLEANPULSE_2
     meta: 
         author = "Mandiant"  
         date_created = "2021-05-17" 
-        SHA256: 9308cfbd697e4bf76fcc8ff71429fbdfe375441e8c8c10519b6a73a776801ba7 
-        reference url= "" 
+        sha256 = "9308cfbd697e4bf76fcc8ff71429fbdfe375441e8c8c10519b6a73a776801ba7" 
+        reference_url = "https://www.fireeye.com/blog/threat-research/2021/05/updates-on-chinese-apt-compromising-pulse-secure-vpn-devices.html"  
     strings: 
         $sb1 = { 00 89 4C 24 08 FF 52 04 8D 00 } 
         $ss1 = "\x00OK!\x00" 


### PR DESCRIPTION
Encountered some errors when trying to use the latest yara signatures. Troubleshooting identified it was due to syntax errors in the meta section. Pull request corrects the syntax errors and adds in the URL reference to the latest FE report. 